### PR TITLE
Fix loadDnaFrom from_end and WorkGroup.execute crash

### DIFF
--- a/include/dna_loader.hpp
+++ b/include/dna_loader.hpp
@@ -30,17 +30,23 @@ struct DnaLoader
 			infile.seekg(offset * bytes_count, std::ios_base::beg);
 		}
 		else {
-			infile.seekg(offset * bytes_count, std::ios_base::end);
+			infile.seekg(-(std::streamoff)(offset + 1) * bytes_count, std::ios_base::end);
 		}
 
 		std::vector<float> test_vec(202);
 		if (!infile.read((char*)test_vec.data(), bytes_count)) {
-			std::cout << "Error while reading file." << std::endl;
+			std::cout << "Error 1 while reading file at " << offset << std::endl;
 		}
 
-		infile.seekg(offset * bytes_count, std::ios_base::beg);
+		if (!from_end) {
+			infile.seekg(offset * bytes_count * -1, std::ios_base::beg);
+		}
+		else {
+			infile.seekg(-(std::streamoff)(offset + 1) * bytes_count, std::ios_base::end);
+		}
+
 		if (!infile.read((char*)dna.code.data(), bytes_count)) {
-			std::cout << "Error while reading file." << std::endl;
+			std::cout << "Error 2 while reading file at " << offset << std::endl;
 		}
 
 		return dna;

--- a/include/selector.hpp
+++ b/include/selector.hpp
@@ -6,6 +6,7 @@
 #include "double_buffer.hpp"
 #include <fstream>
 #include <sstream>
+#include <chrono>
 #include "dna_loader.hpp"
 
 
@@ -24,6 +25,7 @@ struct Selector
 	std::string out_file;
 	uint32_t dump_frequency = 10;
 	uint32_t generation;
+	std::chrono::time_point<std::chrono::high_resolution_clock> start_time = std::chrono::high_resolution_clock::now();
 
 	Selector(const uint32_t agents_count)
 		: population(agents_count)
@@ -59,7 +61,8 @@ struct Selector
 		std::vector<T>& next_units    = population.getLast();
 		wheel.addFitnessScores(current_units);
 		// Replace the weakest
-		std::cout << "Gen: " << generation << " Best: " << current_units[0].fitness << std::endl;
+		std::chrono::duration<double> diff = std::chrono::high_resolution_clock::now() - start_time;
+		std::cout << std::fixed << std::setprecision(3) << diff.count() << " Gen: " << generation << " Best: " << current_units[0].fitness << std::endl;
 		if ((generation%dump_frequency) == 0) {
 			DnaLoader::writeDnaToFile(out_file, getCurrentPopulation()[0].dna);
 		}

--- a/include/stadium.hpp
+++ b/include/stadium.hpp
@@ -50,7 +50,7 @@ struct Stadium
 		const uint64_t bytes_count = Network::getParametersCount(architecture) * 4;
 		const uint64_t dna_count = DnaLoader::getDnaCount(filename, bytes_count);
 		for (uint64_t i(0); i < dna_count && i < population_size; ++i) {
-			const DNA dna = DnaLoader::loadDnaFrom(filename, bytes_count, i);
+			const DNA dna = DnaLoader::loadDnaFrom(filename, bytes_count, i, true);
 			selector.getCurrentPopulation()[i].loadDNA(dna);
 		}
 	}


### PR DESCRIPTION
Fix loadDnaFrom from_end
Load dna from end
Print time since start to console
Fix WorkGroup.execute crash when running stadium.update multiple times at a row